### PR TITLE
Better control of the file size mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,14 @@ or allocate a new block when needed. The file may be automatically resized (expa
 To start using a memory-mapped file as a storage call `emmap:init_block_storage/2` providing emmap
 handler and block size (it will be saved in the storage header).
 
+The new flag `fit` added to emmap:open/4 option list. When set and the existing file opened has a size
+less than requested region length, the file will be stretched to the given length. If the file size is
+greater than requested, with fit flag the mapped region will fit the file size. Without the `fit` flag
+attempt to map existing file of a different size will result in error.
+
 ```erlang
   % open underlying memory-mapped file
-  {ok, MFile, Info} = emmap:open("storage.bin", 0, 4096, [create, write, shared]),
+  {ok, MFile, Info} = emmap:open("storage.bin", 0, 4096, [create, write, fit, shared]),
 
   % init block storage of the fixed block size
   ok = emmap:init_block_storage(MFile, 22),

--- a/test/block_storage_tests.erl
+++ b/test/block_storage_tests.erl
@@ -4,7 +4,8 @@
 
 basic_test() ->
   % open underlying memory-mapped file
-  {ok, MFile, #{size := 1}} = emmap:open("/tmp/simple.bin", 0, 1, [create, write, shared]),
+  {ok, MFile, #{size := X}} = emmap:open("/tmp/simple.bin", 0, 1, [create, fit, write, shared]),
+  ?assert(X >= 1),
 
   % init block storage of the fixed block size
   ok = emmap:init_block_storage(MFile, 1),
@@ -103,7 +104,8 @@ big_random_test() ->
   Iterations = 100_000,
   MaxSize = 200,
 
-  {ok, MFile, #{size := 1}} = emmap:open(FileName, 0, 1, [create, write, shared]),
+  {ok, MFile, #{size := N}} = emmap:open(FileName, 0, 1, [create, fit, write, shared]),
+  ?assert(N >= 1),
   ok = emmap:init_block_storage(MFile, BlockSize),
 
   Acc = loop(Iterations, MFile, #{}, fun
@@ -167,7 +169,8 @@ repair_chunks(MFile, Start, N) ->
   repair_chunks(MFile, Cont, N).
 
 block_storage_test() ->
-  {ok, MFile, #{size := 8}} = emmap:open("/tmp/storage.bin", 0, 8, [create, write, shared]),
+  {ok, MFile, #{size := N}} = emmap:open("/tmp/storage.bin", 0, 8, [create, fit, write, shared]),
+  ?assert(N >= 8),
   ok = emmap:init_block_storage(MFile, 8),
   write_n_blocks(4096, MFile, 8),
 


### PR DESCRIPTION
The recent changes introduced a bug - when mapping existing files and the file size didn't match the requested mmap size, no error was detected, this might result in a bus error if the file size was less than the memory region size.
Now this bug is fixed.
In addition, the new flag `fit` was added to the `emmap:open/4` option list. When set and the existing file opened has a size less than the requested region length, the file will be resized to the given length. If the file size is greater than requested, with a `fit` flag the mapped region size will be set to the file size.