### PR TITLE
Fix TOCTTOU when opening, truncate it normally

### DIFF
--- a/c_src/emmap.cpp
+++ b/c_src/emmap.cpp
@@ -520,22 +520,28 @@ static ERL_NIF_TERM emmap_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
 
   int fd = -1;
 
-  bool reuse = (open_flags & O_CREAT) == 0;
   bool exists = false;
 
   if ((flags & MAP_ANON) == 0) {
-    exists = access(path, F_OK) == 0;
-
-    if (!exists) {
-      if (len == 0)
-        return make_error_tuple(env, "File doesn't exist, zero Len and missing {size, N} option");
-      if (reuse)
-        return make_error_tuple(env, "Missing 'create' option");
+    if ((open_flags & O_CREAT) != 0) {
+      fd = open(path, open_flags | O_EXCL, (mode_t)mode);
+      if (fd < 0) {
+        exists = true;
+        fd = open(path, open_flags, (mode_t)mode);
+      }
+    } else {
+      exists = true;
+      fd = open(path, open_flags, (mode_t)mode);
     }
 
-    fd = open(path, open_flags, (mode_t)mode);
-
     if (fd < 0) {
+      if (errno == ENOENT) {
+        if (len == 0)
+          return make_error_tuple(env, "File doesn't exist, zero Len and missing {size, N} option");
+        if ((open_flags & O_CREAT) != 0)
+          return make_error_tuple(env, "Missing 'create' option");
+      }
+
       debug(dbg, "open: %s\r\n", strerror_compat(errno));
       return make_error_tuple(env, errno);
     }

--- a/c_src/emmap.cpp
+++ b/c_src/emmap.cpp
@@ -565,17 +565,9 @@ static ERL_NIF_TERM emmap_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
       return make_error_tuple(env, buf);
     }
 
-    bool resized = false, resize_ok = true;
     // Stretch the file size to the requested size
     if (fsize == 0 || (fit && fsize < long(len))) {
-      resized = true;
-      resize_ok = ftruncate(fd, len) == 0;
-    }
-    // Set mapped region length to the greater file size
-    if (fit && fsize > long(len)) len = fsize;
-
-    if (resized) {
-      if (resize_ok)
+      if (ftruncate(fd, len) == 0)
         debug(dbg, "File %s resized to %d bytes\r\n", path, len);
       else {
         debug(dbg, "ftruncate: %s\r\n", strerror_compat(errno));
@@ -584,6 +576,8 @@ static ERL_NIF_TERM emmap_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
         return make_error_tuple(env, err);
       }
     }
+    // Set mapped region length to the greater file size
+    if (fit && fsize > long(len)) len = fsize;
   }
 
   off_t pa_offset = 0;

--- a/c_src/emmap.cpp
+++ b/c_src/emmap.cpp
@@ -566,22 +566,13 @@ static ERL_NIF_TERM emmap_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
     }
 
     bool resized = false, resize_ok = true;
-    if (exists) {
-      // Stretch the file size to the requested size
-      if (fsize == 0 || (fit && fsize < long(len))) {
-        resized = true;
-        resize_ok = ftruncate(fd, len) == 0;
-      }
-      // Set mapped region length to the greater file size
-      if (fit && fsize > long(len)) len = fsize;
+    // Stretch the file size to the requested size
+    if (fsize == 0 || (fit && fsize < long(len))) {
+      resized = true;
+      resize_ok = ftruncate(fd, len) == 0;
     }
-    else {
-      // Truncate, then stretch file
-      if ((open_flags & (O_CREAT|O_TRUNC)) > 0) {
-        resized = true;
-        resize_ok = ftruncate(fd, len) == 0;
-      }
-    }
+    // Set mapped region length to the greater file size
+    if (fit && fsize > long(len)) len = fsize;
 
     if (resized) {
       if (resize_ok)

--- a/c_src/emmap.cpp
+++ b/c_src/emmap.cpp
@@ -579,7 +579,7 @@ static ERL_NIF_TERM emmap_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
       // Truncate, then stretch file
       if ((open_flags & (O_CREAT|O_TRUNC)) > 0) {
         resized = true;
-        resize_ok = ftruncate(fd, 0) == 0 && ftruncate(fd, len) == 0;
+        resize_ok = ftruncate(fd, len) == 0;
       }
     }
 


### PR DESCRIPTION
`if(access(f)) /* anything */; open(f)` is always wrong. Instead, detect "we created this" correctly.

Sponsored-by: https://beaverlabs.net