### PR TITLE
Make {size, N} real

### DIFF
--- a/c_src/emmap.cpp
+++ b/c_src/emmap.cpp
@@ -353,10 +353,10 @@ static ERL_NIF_TERM make_error(ErlNifEnv* env, ERL_NIF_TERM err_atom) {
   return enif_make_tuple2(env, ATOM_ERROR, err_atom);
 }
 
-static bool decode_flags(ErlNifEnv* env, ERL_NIF_TERM list, int* prot, int* flags, 
+static bool decode_flags(ErlNifEnv* env, ERL_NIF_TERM list, int* prot, int* flags,
                          long* open_flags,  long* mode, bool* direct, bool* lock,
                          bool* auto_unlink, size_t* address, bool* debug,
-                         size_t* max_inc_size, bool* fixed_size, bool* fit)
+                         size_t* max_inc_size, bool* fixed_size, bool* fit, unsigned long *len)
 {
   bool   l = true;
   bool   d = false;
@@ -463,6 +463,11 @@ static bool decode_flags(ErlNifEnv* env, ERL_NIF_TERM list, int* prot, int* flag
         if (tmp > 0)  // Otherwise use default size
           *max_inc_size = tmp;
         continue;
+      } else if (enif_is_identical (tuple[0], ATOM_SIZE) &&
+                 enif_get_ulong(env,tuple[1], &tmp)) {
+        if (*len == 0)
+          *len = tmp;
+        continue;
       } else
         return false;
     } else {
@@ -510,7 +515,7 @@ static ERL_NIF_TERM emmap_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
       || !enif_get_ulong(env, argv[2], &len)
       || !decode_flags(env, argv[3], &prot, &flags, &open_flags, &mode,
                        &direct, &lock, &auto_unlink,
-                       &address, &dbg, &max_inc_size, &fixed_size, &fit))
+                       &address, &dbg, &max_inc_size, &fixed_size, &fit, &len))
     return enif_make_badarg(env);
 
   int fd = -1;
@@ -523,7 +528,7 @@ static ERL_NIF_TERM emmap_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
 
     if (!exists) {
       if (len == 0)
-        return make_error_tuple(env, "Missing {size, N} option");
+        return make_error_tuple(env, "File doesn't exist, zero Len and missing {size, N} option");
       if (reuse)
         return make_error_tuple(env, "Missing 'create' option");
     }


### PR DESCRIPTION
Before:
```
1> emmap:open("filefilefile", [{size, 33},create,debug,write]).
** exception error: bad argument
     in function  emmap:open_nif/4
        called as emmap:open_nif("filefilefile",0,0,[{size,33},create,debug,write])
     in call from emmap:open/4 (/home/nabijaczleweli/uwu/emmap/src/emmap.erl, line 211)
2> emmap:open("filefilefile", [create,debug,write]).
{error,"Missing {size, N} option"}
```

After:
```
8> emmap:open("filefilefile", [{size, 33},create,debug,write]).
File filefilefile resized to 33 bytes
Created memory map 0x7f44551a4000 of size 33 (filefilefile)
{ok,{file_descriptor,emmap,
                     #Ref<0.2790770119.2734030851.134218>},
    #{exist => true,size => 33}}
```

Closes: #7